### PR TITLE
Fix issue Edge win 10 check that node getAttribute

### DIFF
--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -230,7 +230,7 @@ export default class Autosuggest extends Component {
       event.target;
 
     while (node !== null && node !== document) {
-      if (node.getAttribute('data-suggestion-index') !== null) {
+      if (node.getAttribute && node.getAttribute('data-suggestion-index') !== null) {
         // Suggestion was clicked
         return;
       }
@@ -249,7 +249,7 @@ export default class Autosuggest extends Component {
     let node = startNode;
 
     do {
-      if (node.getAttribute('data-suggestion-index') !== null) {
+      if (node.getAttribute && node.getAttribute('data-suggestion-index') !== null) {
         return node;
       }
 


### PR DESCRIPTION
Clicking on an svg element in Edge ie 10 brakes

Object doesn't support property or method 'getAttribute'